### PR TITLE
Remove Cell __str__ method as it's not useful and abstracting ascii g…

### DIFF
--- a/mazes/grid.py
+++ b/mazes/grid.py
@@ -44,10 +44,6 @@ class Cell(object):
     ls.append(self.west)
     return ls
 
-  def __str__(self):
-    print('{}:{}:{}:{}'.format(
-      self.north, self.east, self.south, self.west))
-
   def to_svg_list(self, scx, scy):
     """Generate a list of SVG strings creating lines.
 


### PR DESCRIPTION
…eneration to cells feels less clean than doing it in the main Grid method.